### PR TITLE
Link to the "Try out the API" page

### DIFF
--- a/committees.html
+++ b/committees.html
@@ -41,6 +41,10 @@
                 </li>
               
             </ul>
+            
+      <li>
+        <a href="http://tryit.sunlightfoundation.com/openstates">Try out the API</a> in your browser.
+      </li>
           
         </li>
       


### PR DESCRIPTION
This is consistent with https://sunlightlabs.github.io/congress/committees.html (there is other content, such as the twitter link, and GitHub link that could be carried over from there, as well.) 

(It would also be helpful to link from the Try It pages to the documentation, across the board.)